### PR TITLE
[FEATURE] Mui Icon Button 새로운 prop 생성

### DIFF
--- a/src/components/icon-button/icon-button-theme.ts
+++ b/src/components/icon-button/icon-button-theme.ts
@@ -1,0 +1,12 @@
+import { alpha } from '@mui/material';
+import { Components } from '@mui/material/styles/components';
+
+export const IconButtonTheme = (
+  cloudplexPalette: any
+): Components['MuiIconButton'] => ({
+  defaultProps: {},
+  styleOverrides: {
+    root: ({ ownerState }) => ({}),
+  },
+  variants: [],
+});

--- a/src/components/icon-button/icon-button.stories.tsx
+++ b/src/components/icon-button/icon-button.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+
+import DeleteIcon from '@mui/icons-material/Delete';
+import { IconButton } from './icon-button';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Components/IconButton',
+  component: IconButton,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const outlined: Story = {
+  args: {
+    color: 'primary',
+    size: 'small',
+    variant: 'outlined',
+    children: <DeleteIcon />,
+  },
+};
+export const contained: Story = {
+  args: {
+    color: 'primary',
+    size: 'small',
+    variant: 'contained',
+    children: <DeleteIcon />,
+  },
+};
+
+export const circled: Story = {
+  args: {
+    color: 'primary',
+    size: 'small',
+    variant: 'contained',
+    circled: true,
+    children: <DeleteIcon />,
+  },
+};

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from 'react';
+import { StyledIconButton } from './styled';
+import { IIconButtonProps } from './types';
+
+export const IconButton: FC<IIconButtonProps> = ({ children, ...props }) => {
+  return <StyledIconButton {...props}>{children}</StyledIconButton>;
+};

--- a/src/components/icon-button/styled.ts
+++ b/src/components/icon-button/styled.ts
@@ -1,0 +1,21 @@
+import { IconButton as MuiIconButton } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { IIconButtonProps } from './types';
+
+const variantMixIn = ({ theme, variant }: any) => ({
+  ...(variant === 'contained' && {
+    backgroundColor: theme.palette.green[100],
+  }),
+  ...(variant === 'outlined' && {
+    backgroundColor: theme.palette.red[100],
+  }),
+});
+
+export const StyledIconButton = styled(MuiIconButton, {
+  shouldForwardProp: prop => !['variant', 'circled'].includes(String(prop)),
+})<IIconButtonProps>(({ theme, variant, circled }) => ({
+  ...(variant !== undefined && variantMixIn({ theme, variant })),
+  ...(circled === true && {
+    border: `1px dashed #f00`,
+  }),
+}));

--- a/src/components/icon-button/types.ts
+++ b/src/components/icon-button/types.ts
@@ -1,0 +1,5 @@
+import { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton/IconButton';
+export interface IIconButtonProps extends MuiIconButtonProps {
+  variant?: 'outlined' | 'contained';
+  circled?: boolean;
+}


### PR DESCRIPTION
### 반영 브랜치
feature/icon-button -> main

### 변경 사항
icon button은 button과 달리, Override 가능한 interface가 제공되지 않음.
createTheme으로는 원래 제공하지 않던 props에 대한 확장이 불가,
ex) icon button의 variant가 없기 때문에
```
<IconButton variant={'contained'} />
```
위의 코드는 동작하지 않고 타입 에러가 발생함.

따라서, interface를 확장해 PDC의 확장된 컴포넌트를 만들어야함.

### 테스트 결과
icon-button/types.ts
```
import { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton/IconButton';
export interface IIconButtonProps extends MuiIconButtonProps {
  variant?: 'outlined' | 'contained';
  circled?: boolean;
}
```
위와 같이 확장된 prop들 모두 정상 동작 확인.

### 주의사항
스타일 적용 확인을 위해 backgroundColor 에 빨간색 초록색 등 간단한 컬러가 입혀져 있음,
추후 디자인에 따라 변경이 필요함.