### PR TITLE
[fix] component: typography component 받을 수 있도록 수정

### DIFF
--- a/src/components/typography/theme.ts
+++ b/src/components/typography/theme.ts
@@ -3,5 +3,4 @@ import { Components } from '@mui/material/styles/components';
 export const TypographyTheme = (
     theme: any
 ): Components['MuiTypography'] => ({
-    defaultProps: {},
 });

--- a/src/components/typography/types.ts
+++ b/src/components/typography/types.ts
@@ -1,5 +1,7 @@
 
-import { TypographyProps as MuTypographyProps } from '@mui/material/Typography';
+import { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
+import {ReactNode} from "react";
 
-export interface TypographyProps extends MuTypographyProps {
+export interface TypographyProps extends MuiTypographyProps {
+    component?: ReactNode;
 }

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -6,8 +6,11 @@ import { StyledTypography } from './styled';
 export const Typography: FC<TypographyProps> = (props, {
     ...restProps
 }) => {
+
+
     return (
         <StyledTypography
+            as={props.component}
             {...props}
             {...restProps}
         >


### PR DESCRIPTION
### 작업 유형
버그 수정 

### 반영 브랜치
feat/typography -> main

### 변경 사항
기존 타이포그라피가 component를 받게 되어 있지 않아서, types 에 component 추가함
[https://mui.com/material-ui/api/typography/](https://mui.com/material-ui/api/typography/
)

[https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Typography/Typography.d.ts](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Typography/Typography.d.ts)